### PR TITLE
Add config option to have a switch instead of a light bulb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ You may also want to create a dummy switch that turns itself on one second after
 
 ```
 
+## Light Bulb or Switch
+
+By default, a switch will appear as a light bulb in Homebridge and the Home app. You can configure your Light Bulb to appear as a Switch instead. This is more convenient when not controlling a light bulb. This can be done by passing the 'switch' argument in your config.json:
+
+```
+    "accessories": [
+        {
+          "accessory": "DummySwitch",
+          "name": "My Stateful Switch 1",
+          "switch": true
+        }   
+    ]
+
+```
+
 ## My modified version of this creates a Contact Sensor to complement the switch.
 
 This is to allow my plugin homebridge-alexa the ability to trigger routines from the contact sensor.

--- a/index.js
+++ b/index.js
@@ -16,9 +16,15 @@ function DummySwitch(log, config) {
   this.stateful = config.stateful;
   this.reverse = config.reverse;
   this.contact = config['contact'] || false;
-  this._service = new Service.Lightbulb(this.name);
-  this._service
-    .addCharacteristic(Characteristic.Brightness);
+  this.switch = config['switch'] || false;
+
+  if (this.switch) {
+    this._service = new Service.Switch(this.name);
+  } else {
+    this._service = new Service.Lightbulb(this.name);
+    this._service
+      .addCharacteristic(Characteristic.Brightness);
+  }
 
   this._contact = new Service.ContactSensor(this.name);
 


### PR DESCRIPTION
Add optional config option to have a switch instead of a light bulb. It defaults to light bulb but turns into a switch if set and true.